### PR TITLE
Added virtualenv folders to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ local_settings.py
 checklistdb
 default
 build/*
+.Python
+bin/
+include/
+lib/


### PR DESCRIPTION
Some of us are weird and keep the virtualenv folders (bin,include etc) in the project folder.
