### PR TITLE
Fixes #50 by adding a description field (see WARNING below)

### DIFF
--- a/checklisthq/checklisthq/settings.py
+++ b/checklisthq/checklisthq/settings.py
@@ -134,7 +134,8 @@ INSTALLED_APPS = (
     #'django.contrib.admin',
     # Uncomment the next line to enable admin documentation:
     #'django.contrib.admindocs',
-    'main'
+    'main',
+    'south'
 )
 
 # A sample logging configuration. The only tangible logging

--- a/checklisthq/main/forms.py
+++ b/checklisthq/main/forms.py
@@ -10,8 +10,10 @@ class ChecklistForm(forms.ModelForm):
     """
     class Meta:
         model = Checklist
-        fields = ('title', 'content', 'tags')
+        fields = ('title', 'description', 'content', 'tags')
         widgets = {
+            'description': Textarea(attrs={'rows': 2, 'style': 'width:100%;',
+                'class': 'input-xlarge'}),
             'content': Textarea(attrs={'rows': 16, 'style': 'width:100%;',
                 'class': 'input-xlarge'}),
         }

--- a/checklisthq/main/migrations/0001_initial.py
+++ b/checklisthq/main/migrations/0001_initial.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'Checklist'
+        db.create_table('main_checklist', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('title', self.gf('django.db.models.fields.CharField')(max_length=512)),
+            ('owner', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['auth.User'])),
+            ('content', self.gf('django.db.models.fields.TextField')()),
+            ('created', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, blank=True)),
+            ('modified', self.gf('django.db.models.fields.DateTimeField')(auto_now=True, auto_now_add=True, blank=True)),
+            ('deleted', self.gf('django.db.models.fields.BooleanField')(default=False)),
+        ))
+        db.send_create_signal('main', ['Checklist'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'Checklist'
+        db.delete_table('main_checklist')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'main.checklist': {
+            'Meta': {'object_name': 'Checklist'},
+            'content': ('django.db.models.fields.TextField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'auto_now_add': 'True', 'blank': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '512'})
+        },
+        'taggit.tag': {
+            'Meta': {'object_name': 'Tag'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '100'})
+        },
+        'taggit.taggeditem': {
+            'Meta': {'object_name': 'TaggedItem'},
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'taggit_taggeditem_tagged_items'", 'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'object_id': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'tag': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'taggit_taggeditem_items'", 'to': "orm['taggit.Tag']"})
+        }
+    }
+
+    complete_apps = ['main']

--- a/checklisthq/main/migrations/0002_auto__add_field_checklist_description.py
+++ b/checklisthq/main/migrations/0002_auto__add_field_checklist_description.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Checklist.description'
+        db.add_column('main_checklist', 'description',
+                      self.gf('django.db.models.fields.TextField')(default=''),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Checklist.description'
+        db.delete_column('main_checklist', 'description')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'main.checklist': {
+            'Meta': {'object_name': 'Checklist'},
+            'content': ('django.db.models.fields.TextField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'description': ('django.db.models.fields.TextField', [], {'default': "''"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'auto_now_add': 'True', 'blank': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '512'})
+        },
+        'taggit.tag': {
+            'Meta': {'object_name': 'Tag'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '100'})
+        },
+        'taggit.taggeditem': {
+            'Meta': {'object_name': 'TaggedItem'},
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'taggit_taggeditem_tagged_items'", 'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'object_id': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'tag': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'taggit_taggeditem_items'", 'to': "orm['taggit.Tag']"})
+        }
+    }
+
+    complete_apps = ['main']

--- a/checklisthq/main/models.py
+++ b/checklisthq/main/models.py
@@ -7,6 +7,7 @@ from taggit.managers import TaggableManager
 class Checklist(models.Model):
     title = models.CharField(max_length=512)
     owner = models.ForeignKey(User)
+    description = models.TextField(default="")
     content = models.TextField()
     created = models.DateTimeField(auto_now_add=True)
     modified = models.DateTimeField(auto_now=True, auto_now_add=True)

--- a/checklisthq/main/templates/_checklists.html
+++ b/checklisthq/main/templates/_checklists.html
@@ -31,6 +31,7 @@
         </div>
       </td>
     </tr>
+    <tr><td style="padding-bottom: 1em;" colspan="5">{{ checklist.description|truncatechars:140 }}</td></tr>
     {% endfor %}
   </tbody>
 </table>

--- a/checklisthq/main/templates/_metadata.html
+++ b/checklisthq/main/templates/_metadata.html
@@ -1,2 +1,11 @@
-        <p><small>Created by: {{checklist.owner.username}}.
-        Last updated: {{checklist.modified}}</small></p>
+{% if checklist.description %}
+<p id="partial_description">
+{{ checklist.description|truncatechars:140 }}
+{% if checklist.description|length|get_digit:"-1" > 140 %}<a href="#" onclick="$('#full_description').toggle();$('#partial_description').toggle();return false;">view all</a>{% endif %}
+</p>
+<p id="full_description" style="display:none;">
+{{ checklist.description }}
+</p>
+{% endif %}
+<p><small>Created by: {{checklist.owner.username}}.
+Last updated: {{checklist.modified}}</small></p>

--- a/checklisthq/main/templates/user/edit_checklist.html
+++ b/checklisthq/main/templates/user/edit_checklist.html
@@ -19,6 +19,8 @@
             {{ form.non_field_errors }}
             <strong>{{ form.title.label }}:</strong>
             {{ form.title }}<br/>
+            <strong>{{ form.description.label }}:</strong>
+            {{ form.description }}<br/>
             {{ form.content }}<br/>
             <strong>{{ form.tags.label }}:</strong>
             {{ form.tags }}

--- a/checklisthq/main/templates/view_checklist.html
+++ b/checklisthq/main/templates/view_checklist.html
@@ -3,7 +3,7 @@
 <div class="container">
     <div class="row">
         <div class="span8 offset2">
-        <h1 style="font-size: 48px; line-height: 64px;">{{ checklist.title }}</h1>
+        <h1 style="font-size: 36px;">{{ checklist.title }}</h1>
         {% include '_metadata.html' %}
         {% include '_tags.html' %}
         <hr/>

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ django-taggit
 requests
 ChecklistDSL
 selenium
+South


### PR DESCRIPTION
Adds a description field that can be added to each checklist and..
- Shows a truncated description in the search results
- Shows a trunctated (but expandable) description on the view view.
- Does not yet search description (but should when previous PR is merged)
- Adds south - see below...

WARNING: This PR introduces south.

You will need to syncdb to get the south tables added, but DO NOT RUN MIGRATE.
There are some issues:
1. You may well have to cheat if you have an earlier DB by not running the initial
   migration.
   
   insert into south_migrationhistory values(1, "main", "0001_initial", date());
2. If already setup you may need to fake the taggit migrations as follows:
   
   ./manage.py migrate taggit --fake
